### PR TITLE
Update align_conformers in jupyter

### DIFF
--- a/ppqm/jupyter.py
+++ b/ppqm/jupyter.py
@@ -73,7 +73,7 @@ def show_molobjs(molobjs, align_conformers=True):
     n_molobjs = len(molobjs)
 
     def _view_molobj(idx):
-        show_molobj(molobjs[idx])
+        show_molobj(molobjs[idx], align_conformers=align_conformers)
 
     interact(
         _view_molobj,


### PR DESCRIPTION
in the event that one wants to see multiple conformers and decide to use a different alignment than the default alignment, it is imperative that the relevant argument is passed down all the way in subsequent function calls otherwise it might be confusing to the user when the option is set to a non-default option but the behavior will remain the same under the circumstances that are given in the initial settings from the developers which might although be settings that are appropriate for most uses that could be performed using this code