### PR TITLE
Isomer Enumeration

### DIFF
--- a/tests/test_chembridge.py
+++ b/tests/test_chembridge.py
@@ -72,6 +72,30 @@ def test_enumerate_stereocenters():
     assert smiles_prime in smiles_list
 
 
+def test_enumerate_stereocenters_multiple():
+
+    start_smi = "BrC=CC1OC(C2)(F)C2(Cl)C1"
+    all_isomer_smis = set([
+        "F[C@@]12C[C@]1(Cl)C[C@@H](/C=C/Br)O2",
+        "F[C@@]12C[C@]1(Cl)C[C@@H](/C=C\Br)O2",
+        "F[C@@]12C[C@]1(Cl)C[C@H](/C=C/Br)O2",
+        "F[C@@]12C[C@]1(Cl)C[C@H](/C=C\Br)O2",
+        "F[C@]12C[C@@]1(Cl)C[C@@H](/C=C/Br)O2",
+        "F[C@]12C[C@@]1(Cl)C[C@@H](/C=C\Br)O2",
+        "F[C@]12C[C@@]1(Cl)C[C@H](/C=C/Br)O2",
+        "F[C@]12C[C@@]1(Cl)C[C@H](/C=C\Br)O2",
+    ])
+
+    molobj = Chem.MolFromSmiles(start_smi)
+    assert molobj is not None
+
+    # Get all enuerated stereo-centers
+    molobj_list = chembridge.enumerate_stereocenters(molobj)
+    stereo_smiles = set([Chem.MolToSmiles(mol) for mol in molobj_list])
+
+    assert stereo_smiles == all_isomer_smis
+
+
 def test_find_max_feature():
     smiles = "CCCCCC.CCCCO"
     smiles_prime = "CCCCO"


### PR DESCRIPTION
The implementation of the enumeration of stereoisomers currently leaves out isomers if there are more than two unassigned stereocenters. Moreover, the maximum number of unassigned stereocenters is hard-coded. This PR addresses these issues and adds a test of stereocenter enumeration to consider a case with more stereocenters. 