### PR TITLE
Small adjustments for PR

### DIFF
--- a/ppqm/orca.py
+++ b/ppqm/orca.py
@@ -106,7 +106,7 @@ class OrcaCalculator(BaseCalculator):
 
     def calculate(self, molobj: Mol, options: dict) -> List[Optional[dict]]:
 
-        if self.n_cores and self.n_cores > 1:
+        if self.n_cores > 1:
             return self.calculate_parallel(molobj, options)
 
         return self.calculate_serial(molobj, options)
@@ -163,9 +163,9 @@ class OrcaCalculator(BaseCalculator):
 
         # If not singlet "spin" is part of options
         if "spin" in options.keys():
-            spin = str(options.pop("spin"))
+            spin = int(options.pop("spin"))
         else:
-            spin = str(1)
+            spin = int(1)
 
         options_prime = dict(ChainMap(options, self.options))
 

--- a/ppqm/orca.py
+++ b/ppqm/orca.py
@@ -11,7 +11,7 @@ from typing import Any, Callable, Dict, List, Optional, Union
 import numpy as np
 from tqdm import tqdm  # type: ignore[import]
 
-from ppqm import chembridge, constants, units
+from ppqm import chembridge, constants
 from ppqm.calculator import BaseCalculator
 from ppqm.chembridge import Mol
 from ppqm.utils import WorkDir, func_parallel, linesio, shell
@@ -429,8 +429,7 @@ def read_properties_sp(lines: List[str], atom_number: int) -> dict:
 
     for line in lines:
         if "FINAL SINGLE POINT ENERGY" in line:
-            # TODO JCK Not sure if there sohuld be a convertion here, might be misleading
-            scf_energy = float(line.split()[4]) * units.hartree_to_kcalmol
+            scf_energy = float(line.split()[4])
             properties[COLUMN_SCF_ENERGY] = scf_energy
             break
 
@@ -496,7 +495,7 @@ def get_gibbs_free_energy(lines: List[str], atom_number: int) -> Optional[dict]:
     gibbs_free_energy = None  # Return None by default
     for line in lines:
         if "Final Gibbs free energy" in line:
-            gibbs_free_energy = float(line.split()[5]) * units.hartree_to_kcalmol
+            gibbs_free_energy = float(line.split()[5])
             break
 
     return {COLUMN_GIBBS_FREE_ENERGY: gibbs_free_energy}
@@ -507,7 +506,7 @@ def get_enthalpy(lines: List[str], atom_number: int) -> Optional[dict]:
     enthalpy = None  # Return None by default
     for line in lines:
         if "Total enthalpy" in line:
-            enthalpy = float(line.split()[3]) * units.hartree_to_kcalmol
+            enthalpy = float(line.split()[3])
             break
 
     return {COLUMN_ENTHALPY: enthalpy}
@@ -518,7 +517,7 @@ def get_entropy(lines: List[str], atom_number: int) -> Optional[dict]:
     entropy = None  # Return None by default
     for line in lines:
         if "Final entropy term" in line:
-            entropy = float(line.split()[4]) * units.hartree_to_kcalmol
+            entropy = float(line.split()[4])
             break
 
     return {COLUMN_ENTROPY: entropy}

--- a/tests/test_orca.py
+++ b/tests/test_orca.py
@@ -392,8 +392,9 @@ def test_parallel(tmp_path: Path) -> None:
     assert len(results)
     assert results[1] is not None
     assert (
-        calc.orca_options["n_cores"] == total_cores / num_conformers
+        calc.orca_options["n_cores"] == total_cores // num_conformers
     )  # update after calc has been called
+    assert calc.n_cores == total_cores  # should not have changed
 
     # test for some values
     scf_energy = results[1]["scf_energy"]

--- a/tests/test_orca.py
+++ b/tests/test_orca.py
@@ -4,19 +4,19 @@ import pytest
 from conftest import RESOURCES
 from rdkit import Chem  # type: ignore[import]
 
-from ppqm import chembridge, orca, tasks, units
+from ppqm import chembridge, orca, tasks
 from ppqm.orca import OrcaCalculator
 
 TEST_ENERGIES_PM3 = [
-    ("O", -11.935809225486 * units.hartree_to_kcalmol),
-    ("CC", -12.124869353328 * units.hartree_to_kcalmol),
-    ("[NH4+]", -7.972867788142 * units.hartree_to_kcalmol),
+    ("O", -11.935809225486),
+    ("CC", -12.124869353328),
+    ("[NH4+]", -7.972867788142),
 ]
 
 TEST_ENERGIES_B3LYP = [
-    ("O", -76.328663632482 * units.hartree_to_kcalmol),
-    ("CC", -79.705551996245 * units.hartree_to_kcalmol),
-    ("[NH4+]", -56.950888890358 * units.hartree_to_kcalmol),
+    ("O", -76.328663632482),
+    ("CC", -79.705551996245),
+    ("[NH4+]", -56.950888890358),
 ]
 
 serine_num_atoms = 14
@@ -218,7 +218,7 @@ def test_get_gibbs_free_energy() -> None:
 
     assert isinstance(result_orca_4["gibbs_free_energy"], float)
 
-    assert result_orca_4["gibbs_free_energy"] == -40.42878184 * units.hartree_to_kcalmol
+    assert result_orca_4["gibbs_free_energy"] == -40.42878184
 
     # orca 5.0.2
 
@@ -230,7 +230,7 @@ def test_get_gibbs_free_energy() -> None:
 
     assert isinstance(result_orca_5["gibbs_free_energy"], float)
 
-    assert result_orca_5["gibbs_free_energy"] == -398.37468900 * units.hartree_to_kcalmol
+    assert result_orca_5["gibbs_free_energy"] == -398.37468900
 
 
 def test_get_enthalpy() -> None:
@@ -251,7 +251,7 @@ def test_get_enthalpy() -> None:
 
     assert isinstance(result_orca_4["enthalpy"], float)
 
-    assert result_orca_4["enthalpy"] == -40.40529550 * units.hartree_to_kcalmol
+    assert result_orca_4["enthalpy"] == -40.40529550
 
     # orca 5.0.2
 
@@ -263,7 +263,7 @@ def test_get_enthalpy() -> None:
 
     assert isinstance(result_orca_5["enthalpy"], float)
 
-    assert result_orca_5["enthalpy"] == -398.33479178 * units.hartree_to_kcalmol
+    assert result_orca_5["enthalpy"] == -398.33479178
 
 
 def test_get_entropy() -> None:
@@ -284,7 +284,7 @@ def test_get_entropy() -> None:
 
     assert isinstance(result_orca_4["entropy"], float)
 
-    assert result_orca_4["entropy"] == 0.02348634 * units.hartree_to_kcalmol
+    assert result_orca_4["entropy"] == 0.02348634
 
     # orca 5.0.2
 
@@ -296,7 +296,7 @@ def test_get_entropy() -> None:
 
     assert isinstance(result_orca_5["entropy"], float)
 
-    assert result_orca_5["entropy"] == 0.03989722 * units.hartree_to_kcalmol
+    assert result_orca_5["entropy"] == 0.03989722
 
 
 def test_read_properties() -> None:
@@ -400,7 +400,7 @@ def test_parallel(tmp_path: Path) -> None:
     scf_energy = results[1]["scf_energy"]
     mulliken_charge = results[1]["mulliken_charges"][0]
 
-    assert pytest.approx(scf_energy, 10**-4) == -178251.589166
+    assert pytest.approx(scf_energy, 10**-4) == -284.06522738493
     assert pytest.approx(mulliken_charge, 10**-1) == 0.111094
 
 

--- a/tests/test_orca.py
+++ b/tests/test_orca.py
@@ -309,8 +309,6 @@ def test_read_properties() -> None:
         "CPCM": "water",
         "RIJCOSX": None,
         "def2/J": None,
-        "Grid4": None,
-        "GridX4": None,
         "NMR": None,
         "def2/JK": None,
     }
@@ -335,8 +333,6 @@ def test_read_properties_compromised_file() -> None:
         "CPCM": "water",
         "RIJCOSX": None,
         "def2/J": None,
-        "Grid4": None,
-        "GridX4": None,
         "NMR": None,
         "def2/JK": None,
     }
@@ -376,9 +372,13 @@ def test_parallel(tmp_path: Path) -> None:
         "CPCM": "water",
         "RIJCOSX": None,
         "def2/J": None,
-        # "Grid4": None,
-        # "GridX4": None,
     }
+
+    # new keywords for integration grid in newer version of orca
+    # https://sites.google.com/site/orcainputlibrary/numerical-precision
+    if int(calc.version[0]) < 5:
+        calculation_option["Grid4"] = None
+        calculation_option["GridX4"] = None
 
     # generate conformers
     molobj_conf = tasks.generate_conformers(molobj, max_conformers=2)
@@ -444,8 +444,6 @@ def test_axyzc_optimize_b3lyp(smiles: str, energy: float, tmp_path: Path) -> Non
         "CPCM": "water",
         "RIJCOSX": None,
         "def2/J": None,
-        # "Grid4": None,
-        # "GridX4": None,
     }
     atoms, coordinates, charge = chembridge.get_axyzc(molobj, atomfmt=str)
 


### PR DESCRIPTION
I adjusted some problems regarding Orca 4 vs Orca 5 in the test suite. The tests now checks which version is used and adds (or doesn't add) specifications for the integration grid. Otherwise there are deviations of the energies calculated.

Other minor changes include

- no conversion to kcal/mol in the orca worker as pointed out by you
- assertions for CPU allocation in parallel calculations

All orca related tests pass for me on Linux Cent OS 7 with Orca 5 installed on Mac OS X with Orca 4 installed.

**Not fixed** and also not working are the notebooks (orca and also xtb). I am not sure if you still want to adjust something and have not done anything about it. Seems like the crash mainly concerns the progress bar. 

I also noticed that tests that invoke xtb do not pass. Let me know if that's a known issue or if you need more information. 