### PR TITLE
Hagen/fix xtb

### DIFF
--- a/ppqm/chembridge.py
+++ b/ppqm/chembridge.py
@@ -254,6 +254,7 @@ def enumerate_stereocenters(
 
     properties = get_properties_from_molobj(molobj)
 
+    Chem.AssignStereochemistry(molobj)
     num_unassigned = CalcNumUnspecifiedAtomStereoCenters(molobj)
     if num_unassigned > max_num_unassigned:
         smi = Chem.MolToSmiles(molobj)

--- a/ppqm/xtb.py
+++ b/ppqm/xtb.py
@@ -329,7 +329,7 @@ def read_properties(
     read_files = True
 
     if options is None:
-        reader = read_properties_opt
+        reader = read_properties_sp
 
     elif "vfukui" in options:
         reader = read_properties_fukui

--- a/tests/test_xtb.py
+++ b/tests/test_xtb.py
@@ -49,6 +49,7 @@ def test_axyzc_optimize(smiles: str, energy: float, tmp_path: Path) -> None:
 
     total_energy = properties[xtb.COLUMN_ENERGY]
     assert xtb.COLUMN_COORD in properties
+    assert len(properties[xtb.COLUMN_COORD]) == len(atoms)
     assert pytest.approx(energy, 10**-2) == total_energy
 
 


### PR DESCRIPTION
The PR fixes two issues: 
* parsing of xtb output, the old function xtb.read_atoms did not read the number of atoms, which created problems for the parsing of the coordinates after optimization. Instead the function relies on the coordinate block in the xtb output to parse the number of atoms. This is only present if a geometry optimization has taken place, but the number of atoms is also only needed there.
* moreover, I have added a Chem.AssignStereoChemistry() in chembridge.enumerate_stereocenters(). If that is not there, rdkit may throw an error when asked to calculate the number of unassigned stereo-centers. 